### PR TITLE
Rbk/fix restarts

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: Restart mysql
-  service: name=mysqld state=restarted
+  service: name=mariadb state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,7 @@
   notify: Restart mysql
 
 - name: Enable service
-  service: name=mysqld state=started enabled=yes
+  service: name=mariadb state=started enabled=yes
 
 - block:
   - name: Secure installation


### PR DESCRIPTION
The newest version of mariadb changed something when creating the links to the startup file.  If you use mysqld instead of mariadb in the handler or with the enable command, the role fails.