### PR TITLE
Revert mysql socket to original location

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,7 +29,7 @@ mysql_packages:
 
 # Path to data
 mysql_datadir: /var/lib/mysql
-mysql_socket: '{{mysql_datadir}}/mysqld.sock'
+mysql_socket: '{{mysql_datadir}}/mysql.sock'
 
 # Set to false if you don't want to run tasks to secure the database
 mysql_secure: true


### PR DESCRIPTION
Commit ab377ce unadvertedly changed the name of the socket from mysql.sock to mysqld.sock.